### PR TITLE
fix virtual service destination routes when match is set

### DIFF
--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"slices"
 	"strings"
 	"time"
 
@@ -721,8 +720,7 @@ func makeDestination(canary *flaggerv1.Canary, host string, weight int) istiov1b
 
 	// set destination port when an ingress gateway is specified
 	if canary.Spec.Service.PortDiscovery &&
-		(len(canary.Spec.Service.Gateways) > 0 &&
-			!slices.Contains(canary.Spec.Service.Gateways, "mesh") || canary.Spec.Service.Delegation) {
+		!slices.Contains(canary.Spec.Service.Gateways, "mesh") || canary.Spec.Service.Delegation) {
 		dest = istiov1beta1.HTTPRouteDestination{
 			Destination: istiov1beta1.Destination{
 				Host: host,

--- a/pkg/router/istio.go
+++ b/pkg/router/istio.go
@@ -709,7 +709,7 @@ func mergeMatchConditions(canary, defaults []istiov1beta1.HTTPMatchRequest) []is
 	return merged
 }
 
-// makeDestination returns a destination weight for the specified host
+// makeDestination returns a an destination weight for the specified host
 func makeDestination(canary *flaggerv1.Canary, host string, weight int) istiov1beta1.HTTPRouteDestination {
 	dest := istiov1beta1.HTTPRouteDestination{
 		Destination: istiov1beta1.Destination{
@@ -720,7 +720,8 @@ func makeDestination(canary *flaggerv1.Canary, host string, weight int) istiov1b
 
 	// set destination port when an ingress gateway is specified
 	if canary.Spec.Service.PortDiscovery &&
-		!slices.Contains(canary.Spec.Service.Gateways, "mesh") || canary.Spec.Service.Delegation) {
+		(len(canary.Spec.Service.Gateways) > 0 &&
+			canary.Spec.Service.Gateways[0] != "mesh" || canary.Spec.Service.Delegation) {
 		dest = istiov1beta1.HTTPRouteDestination{
 			Destination: istiov1beta1.Destination{
 				Host: host,


### PR DESCRIPTION
primary destination is duplicated on both virtual service routes when setting match rules as per the [istio a/b testing](https://docs.flagger.app/tutorials/istio-ab-testing) tutorial:
```yaml
  http:
  - match:
    - headers:
        x-header-1:
          exact: Test_from_DEVs
    route:
    - destination:
        host: podinfo-primary
      weight: 50
    - destination:
        host: podinfo-canary
      weight: 50
  - route:
     - destination:
         host: podinfo-primary
        weight: 50
```
this PR removes the primary destination from canary route to generate and update the virtual service without the duplicate destination:
```yaml
  http:
  - match:
    - headers:
        x-header-1:
          exact: Test_from_DEVs
    route:
    - destination:
        host: podinfo-canary
      weight: 50
  - route:
    - destination:
        host: podinfo-primary
       weight: 50
```